### PR TITLE
Update tokenlist for LIL - 0x22683bbadd01473969f23709879187705a253763

### DIFF
--- a/verified_tokenlist.json
+++ b/verified_tokenlist.json
@@ -36798,5 +36798,13 @@
     "decimals": 9,
     "chainId": 10143,
     "tags": []
+  },
+  {
+    "name": "Lil Coq",
+    "symbol": "LIL",
+    "address": "0x22683bbadd01473969f23709879187705a253763",
+    "decimals": 18,
+    "chainId": 43114,
+    "tags": []
   }
 ]


### PR DESCRIPTION
This pull request updates the tokenlist to include the token LIL with address 0x22683bbadd01473969f23709879187705a253763.