### PR TITLE
Update tokenlist for JPYC - 0xe7c3d8c9a439fede00d2600032d5db0be71c3c29

### DIFF
--- a/verified_tokenlist.json
+++ b/verified_tokenlist.json
@@ -26049,5 +26049,13 @@
     "decimals": 6,
     "chainId": 43114,
     "tags": []
+  },
+  {
+    "name": "JPY Coin",
+    "symbol": "JPYC",
+    "address": "0xe7c3d8c9a439fede00d2600032d5db0be71c3c29",
+    "decimals": 18,
+    "chainId": 43114,
+    "tags": []
   }
 ]


### PR DESCRIPTION
This pull request updates the tokenlist to include the token JPYC with address 0xe7c3d8c9a439fede00d2600032d5db0be71c3c29.